### PR TITLE
fix: crash on getDateOfBirth() if not entered into healthkit yet

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Characteristic.m
@@ -55,6 +55,14 @@
         callback(@[RCTMakeError(@"error getting date of birth", error, nil)]);
         return;
     }
+    if(dob == nil) {
+        NSDictionary *response = @{
+                                   @"value" : [NSNull null],
+                                   @"age" : [NSNull null]
+                                   };
+        callback(@[[NSNull null], response]);
+        return;
+    }
 
     NSString *dobString = [RCTAppleHealthKit buildISO8601StringFromDate:dob];
 


### PR DESCRIPTION
Fixes a crash when attempting to get the date of birth, which the user has not yet added to apple health.
