### PR TITLE
Fixed #4: Corrected dependency constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "author": "Greg Wilson",
   "license": "MIT",
   "devDependencies": {
-    "react-native": "^0.28.0"
+    "react-native": ">=0.28.0"
   },
   "peerDependencies": {
-    "react-native": "^0.28.0"
+    "react-native": ">=0.28.0"
   }
 }


### PR DESCRIPTION
This fixes #4. When specifying `^0.28.0` as version npm will only look for versions `>=0.28.0` and `<=0.29.0`

See also http://jubianchi.github.io/semver-check/
