### PR TITLE
Fix data array for cumulative stats is empty

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Queries.m
@@ -423,7 +423,7 @@
             [RCTAppleHealthKit reverseNSMutableArray:data];
         }
 
-        if(lim > 0) {
+        if((lim > 0) && ([data count] > lim)) {
             NSArray* slicedArray = [data subarrayWithRange:NSMakeRange(0, lim)];
             NSError *err;
             completionHandler(slicedArray, err);


### PR DESCRIPTION
This is a change we've been using in production at Ada.com, essentially, without this error, react-native-apple-healthkit has an error when querying data that is not available – The original author is @codingsparse, he can potentially explain the issue better.