### PR TITLE
fix readme table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,8 @@ The available HealthKit permissions to use with `initHealthKit`
 | BloodPressureSystolic  | [HKQuantityTypeIdentifierBloodPressureSystolic](https://developer.apple.com/reference/healthkit/hkquantitytypeidentifierbloodpressuresystolic?language=objc)   | ✓    |       |
 | BloodPressureDiastolic | [HKQuantityTypeIdentifierBloodPressureDiastolic](https://developer.apple.com/reference/healthkit/hkquantitytypeidentifierbloodpressurediastolic?language=objc) | ✓    |       |
 | RespiratoryRate        | [HKQuantityTypeIdentifierRespiratoryRate](https://developer.apple.com/reference/healthkit/hkquantitytypeidentifierrespiratoryrate?language=objc)               | ✓    |       |
-| BloodGlucose           | [HKQuantityTypeIdentifierBloodGlucose](https://developer.apple.com/reference/healthkit/hkquantitytypeidentifierbloodglucose?language=objc)                     | ✓    |       
-|
-| SleepAnalysis          | [HKCategoryTypeIdentifierSleepAnalysis](https://developer.apple.com/reference/healthkit/hkcategorytypeidentifiersleepanalysis?language=objc)                   | ✓    |     
-|
+| BloodGlucose           | [HKQuantityTypeIdentifierBloodGlucose](https://developer.apple.com/reference/healthkit/hkquantitytypeidentifierbloodglucose?language=objc)                     | ✓    |
+| SleepAnalysis          | [HKCategoryTypeIdentifierSleepAnalysis](https://developer.apple.com/reference/healthkit/hkcategorytypeidentifiersleepanalysis?language=objc)                   | ✓    |
 
 
 These permissions are exported as constants of the `react-native-apple-healthkit` module.


### PR DESCRIPTION
### Issue

Noticed a slight bug in the `README.md` for Permissions table. Fixed so that the `SleepAnalysis` row is 💯 

**BEFORE:**

<img width="1274" alt="screen shot 2017-05-19 at 4 35 30 pm" src="https://cloud.githubusercontent.com/assets/4782621/26267722/514c536a-3cb1-11e7-81a2-bb4fde5e42d5.png">

**AFTER:**

<img width="1173" alt="screen shot 2017-05-19 at 4 39 02 pm" src="https://cloud.githubusercontent.com/assets/4782621/26267830/bd87a26e-3cb1-11e7-8807-be04d9730ca2.png">
